### PR TITLE
bugfix: do proxy if no AAAA records found, e.g. only CNAME records

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -60,7 +60,8 @@ func dns64Parse(c *caddy.Controller) (proxy.Proxy, *net.IPNet, error) {
 				if !c.NextArg() {
 					return prxy, pref, c.ArgErr()
 				}
-				_, pref, err := net.ParseCIDR(c.Val())
+				var err error
+				_, pref, err = net.ParseCIDR(c.Val())
 
 				// test for valid prefix
 				n, total := pref.Mask.Size()

--- a/setup.go
+++ b/setup.go
@@ -6,10 +6,13 @@ import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
+	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/plugin/proxy"
 
 	"github.com/mholt/caddy"
 )
+
+var log = clog.NewWithPlugin("hosts")
 
 func init() {
 	caddy.RegisterPlugin("dns64", caddy.Plugin{

--- a/setup.go
+++ b/setup.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mholt/caddy"
 )
 
-var log = clog.NewWithPlugin("hosts")
+var log = clog.NewWithPlugin("dns64")
 
 func init() {
 	caddy.RegisterPlugin("dns64", caddy.Plugin{

--- a/setup_test.go
+++ b/setup_test.go
@@ -10,58 +10,68 @@ func TestSetupDns64(t *testing.T) {
 	tests := []struct {
 		inputUpstreams string
 		shouldErr      bool
+		prefix         string
 	}{
 		{
 			`dns64`,
 			false,
+			"64:ff9b::/96",
 		},
 		{
 			`dns64 {
     upstream 8.8.8.8
 }`,
 			false,
+			"64:ff9b::/96",
 		},
 		{
 			`dns64 {
     prefix 64:ff9b::/96
 }`,
 			false,
+			"64:ff9b::/96",
 		},
 		{
 			`dns64 {
     prefix 64:ff9b::/32
 }`,
 			false,
+			"64:ff9b::/32",
 		},
 		{
 			`dns64 {
     prefix 64:ff9b::/52
 }`,
 			true,
+			"64:ff9b::/52",
 		},
 		{
 			`dns64 {
     prefix 64:ff9b::/104
 }`,
 			true,
+			"64:ff9b::/104",
 		},
 		{
 			`dns64 {
     prefix 8.8.8.8/24
 }`,
 			true,
+			"8.8.9.9/24",
 		},
 		{
 			`dns64 {
     upstream 8.8.8.8 8.8.4.4
 }`,
 			false,
+			"64:ff9b::/96",
 		},
 		{
 			`dns64 {
     upstream some_not_useable_domain
 }`,
 			true,
+			"64:ff9b::/96",
 		},
 		{
 			`dns64 {
@@ -69,6 +79,23 @@ func TestSetupDns64(t *testing.T) {
     upstream 8.8.8.8
 }`,
 			false,
+			"64:ff9b::/96",
+		},
+		{
+			`dns64 {
+    prefix 2002:ac12:b083::/96
+    upstream 8.8.8.8
+}`,
+			false,
+			"2002:ac12:b083::/96",
+		},
+		{
+			`dns64 {
+    prefix 2002:c0a8:a88a::/48
+    upstream 8.8.8.8
+}`,
+			false,
+			"2002:c0a8:a88a::/48",
 		},
 		{
 			`dns64 foobar {
@@ -76,24 +103,32 @@ func TestSetupDns64(t *testing.T) {
     upstream 8.8.8.8
 }`,
 			true,
+			"64:ff9b::/96",
 		},
 		{
 			`dns64 foobar`,
 			true,
+			"64:ff9b::/96",
 		},
 		{
 			`dns64 {
     foobar
 }`,
 			true,
+			"64:ff9b::/96",
 		},
 	}
 
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.inputUpstreams)
-		_, _, err := dns64Parse(c)
+		_, pref, err := dns64Parse(c)
 		if (err != nil) != test.shouldErr {
 			t.Errorf("Test %d expected %v error, got %v for %s", i+1, test.shouldErr, err, test.inputUpstreams)
+		}
+		if err == nil {
+			if pref.String() != test.prefix {
+				t.Errorf("Test %d expected prefix %s, got %v", i+1, test.prefix, pref.String())
+			}
 		}
 	}
 }


### PR DESCRIPTION
1. Sometimes only CNAME record in response, in this case, we need to do the proxy and DNS64 translate.
e.g.
```
$ dig www.baidu.com @8.8.8.8 AAAA

; <<>> DiG 9.11.3-1ubuntu1.1-Ubuntu <<>> www.baidu.com @8.8.8.8 AAAA
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 3438
;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 1, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;www.baidu.com.			IN	AAAA

;; ANSWER SECTION:
www.baidu.com.		426	IN	CNAME	www.a.shifen.com.
www.a.shifen.com.	90	IN	CNAME	www.wshifen.com.

;; AUTHORITY SECTION:
wshifen.com.		299	IN	SOA	ns1.wshifen.com. baidu_dns_master.baidu.com. 1806210003 60 30 2592000 3600

;; Query time: 67 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Wed Jun 27 12:11:57 CST 2018
;; MSG SIZE  rcvd: 152
```

2. And, use `github.com/coredns/coredns/plugin/pkg/log` for logging.

3. Bugfix: user defined prefix can not setup correctly