### PR TITLE
Add "translateAll" parameter. Fix for #3

### DIFF
--- a/dns64.go
+++ b/dns64.go
@@ -20,6 +20,7 @@ type DNS64 struct {
 	Next   plugin.Handler
 	Proxy  proxy.Proxy
 	Prefix *net.IPNet
+	translateAll bool
 }
 
 // ServeDNS implements the plugin.Handler interface.
@@ -55,7 +56,7 @@ func (r *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	// do not modify if there are AAAA records or NameError. continue if NoData or any other error.
 	ty, _ := response.Typify(res, time.Now().UTC())
 	if ty == response.NoError || ty == response.NameError {
-		if hasAAAA(res) {
+		if hasAAAA(res) && ! r.translateAll {
 			return r.ResponseWriter.WriteMsg(res)
 		}
 	}


### PR DESCRIPTION
Add confguration parameter "translateAll" to force translated A to be returned even if an AAAA response is received.

This is a fix for #3 

The function is needed when testing ipv6 in an environment with only ipv4 access. That is (unfortunately) still the most common case.
