### PR TITLE
Use Go's standard context library

### DIFF
--- a/dns64.go
+++ b/dns64.go
@@ -12,7 +12,7 @@ import (
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // DNS64 performs DNS64.


### PR DESCRIPTION
This is recommended now, you'll get this error upon compiling Coredns.
```** presubmit/context
plugin/dns64/dns64.go
** presubmit/context: please use std lib's 'context' instead
make: *** [Makefile:78: presubmit] Error 1
```