### PR TITLE
Update location of CoreDNS proxy plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,16 @@ file example.com.db
 
 ## Installation
 
-```
+```console
 $ go get github.com/coredns/coredns
 $ go get github.com/serverwentdown/dns64
 $ cd $GOPATH/src/github.com/coredns/coredns
 $ vim plugin.cfg
-# Add the line dns64:github.com/serverwentdown/dns64 before the hosts middleware
+
+Add to end of file:
+proxy:github.com/coredns/proxy
+dns64:github.com/serverwentdown/dns64
+
 $ go generate
 $ go build
 $ ./coredns -plugins | grep dns64

--- a/dns64.go
+++ b/dns64.go
@@ -2,24 +2,24 @@
 package dns64
 
 import (
+	"context"
 	"errors"
 	"net"
 	"time"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/response"
-	"github.com/coredns/coredns/plugin/proxy"
 	"github.com/coredns/coredns/request"
+	"github.com/coredns/proxy"
 
 	"github.com/miekg/dns"
-	"context"
 )
 
 // DNS64 performs DNS64.
 type DNS64 struct {
-	Next   plugin.Handler
-	Proxy  proxy.Proxy
-	Prefix *net.IPNet
+	Next         plugin.Handler
+	Proxy        proxy.Proxy
+	Prefix       *net.IPNet
 	translateAll bool
 }
 
@@ -56,7 +56,7 @@ func (r *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	// do not modify if there are AAAA records or NameError. continue if NoData or any other error.
 	ty, _ := response.Typify(res, time.Now().UTC())
 	if ty == response.NoError || ty == response.NameError {
-		if hasAAAA(res) && ! r.translateAll {
+		if hasAAAA(res) && !r.translateAll {
 			return r.ResponseWriter.WriteMsg(res)
 		}
 	}

--- a/setup.go
+++ b/setup.go
@@ -3,11 +3,12 @@ package dns64
 import (
 	"net"
 	"strconv"
+
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
-	"github.com/coredns/coredns/plugin/pkg/parse"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
-	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/pkg/parse"
+	"github.com/coredns/proxy"
 
 	"github.com/mholt/caddy"
 )


### PR DESCRIPTION
* Use the new external plugin location.
* `go fmt`.
* Update readme.

Fixes: https://github.com/serverwentdown/dns64/issues/7

Signed-off-by: Ben Kochie <superq@gmail.com>